### PR TITLE
fix: Make `mypy` exclude `tests/` directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,9 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unused_ignores = true
 show_error_codes = true
-exclude = "tests"
+exclude = [
+    '^(.*/)?tests/.*$',
+]
 
 [tool.pytest.ini_options]
 addopts = "-ra"


### PR DESCRIPTION
It takes a list of regex pattern strings which are matched against the full path to the Python file being checked.