### PR TITLE
chore: Run `pyupgrade` before `flake8` via `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,12 @@ repos:
   hooks:
   - id: isort
 
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.3.1
+  hooks:
+  - id: pyupgrade
+    args: ['--py37-plus']
+
 - repo: https://github.com/pycqa/flake8
   rev: 6.0.0
   hooks:
@@ -42,9 +48,3 @@ repos:
   hooks:
   - id: mypy
     exclude: 'tests'
-
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.3.1
-  hooks:
-  - id: pyupgrade
-    args: ['--py37-plus']


### PR DESCRIPTION
Pyupgrade might make changes that we want flake8 to check.